### PR TITLE
Fix chat components to send API key

### DIFF
--- a/home/ubuntu/meu-tratado-app/app/components/chat-interface.tsx
+++ b/home/ubuntu/meu-tratado-app/app/components/chat-interface.tsx
@@ -15,12 +15,17 @@ export function ChatInterface() {
     setIsLoading(true);
 
     try {
+      const apiKey = localStorage.getItem('openai-api-key');
+      if (!apiKey) {
+        throw new Error('Chave API não encontrada');
+      }
+
       const res = await fetch('/api/chat', {
         method: 'POST',
         headers: {
           'Content-Type': 'application/json',
         },
-        body: JSON.stringify({ prompt }),
+        body: JSON.stringify({ message: prompt, apiKey }),
       });
 
       if (!res.ok) {
@@ -29,7 +34,7 @@ export function ChatInterface() {
       }
 
       const data = await res.json();
-      setResponse(data.choices[0].message.content);
+      setResponse(data.response);
     } catch (err: any) {
       setError(err.message);
     } finally {

--- a/home/ubuntu/meu-tratado-app/app/components/simple-chat.tsx
+++ b/home/ubuntu/meu-tratado-app/app/components/simple-chat.tsx
@@ -10,28 +10,33 @@ export function SimpleChatInterface() {
 
   const handleSubmit = async (e: React.FormEvent) => {
     e.preventDefault();
-    
+
     if (!prompt.trim()) return;
-    
+
     setLoading(true);
     setError('');
-    
+
     try {
+      const apiKey = localStorage.getItem('openai-api-key');
+      if (!apiKey) {
+        throw new Error('Chave API não encontrada');
+      }
+
       const res = await fetch('/api/chat', {
         method: 'POST',
         headers: {
           'Content-Type': 'application/json',
         },
-        body: JSON.stringify({ prompt }),
+        body: JSON.stringify({ message: prompt, apiKey }),
       });
       
       const data = await res.json();
-      
+
       if (!res.ok) {
         throw new Error(data.error || 'Falha na comunicação com o servidor');
       }
-      
-      setResponse(data.choices[0].message.content);
+
+      setResponse(data.response);
     } catch (err: any) {
       setError(err.message || 'Ocorreu um erro ao processar sua solicitação');
     } finally {


### PR DESCRIPTION
## Summary
- include stored API key when chatting with the backend
- handle API response format changes

## Testing
- `npx tsc --noEmit` *(fails: Cannot find module 'react' ...)*
